### PR TITLE
Fix cursor when hovering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -163,3 +163,7 @@ a>span {
 		display: none;
 	}
 }
+
+.grid div {
+    cursor: pointer;
+}


### PR DESCRIPTION
 Currently, the cursor turns into an "I-beam pointer" when hovering over the text in your little boxes for your projects, organizations, etc.

That felt crappy. Fixed it for ya. I probably didn't break anything else with these three lines of code. 

Probably.